### PR TITLE
Consider also inherited fields

### DIFF
--- a/src/main/java/org/csveed/bean/BeanProperties.java
+++ b/src/main/java/org/csveed/bean/BeanProperties.java
@@ -34,7 +34,7 @@ public class BeanProperties implements Iterable<BeanProperty> {
         parseBean(beanClass);
     }
     
-    public static List<Field> getInheritedFields(Class<?> type) {
+    private List<Field> getInheritedFields(Class<?> type) {
         List<Field> fields = new ArrayList<Field>();
         for (Class<?> c = type; c != null; c = c.getSuperclass()) {
             fields.addAll(0,Arrays.asList(c.getDeclaredFields()));

--- a/src/main/java/org/csveed/bean/BeanProperties.java
+++ b/src/main/java/org/csveed/bean/BeanProperties.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
 
 import java.beans.*;
 import java.lang.reflect.Field;
-import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.util.*;
 
@@ -34,6 +33,14 @@ public class BeanProperties implements Iterable<BeanProperty> {
         this.beanClass = beanClass;
         parseBean(beanClass);
     }
+    
+    public static List<Field> getInheritedFields(Class<?> type) {
+        List<Field> fields = new ArrayList<Field>();
+        for (Class<?> c = type; c != null; c = c.getSuperclass()) {
+            fields.addAll(0,Arrays.asList(c.getDeclaredFields()));
+        }
+        return fields;
+    }    
 
     private void parseBean(Class beanClass) {
         final BeanInfo beanInfo;
@@ -47,7 +54,7 @@ public class BeanProperties implements Iterable<BeanProperty> {
 
         // Note that we use getDeclaredFields here instead of the PropertyDescriptor order. The order we now
         // use is guaranteed to be the declaration order from JDK 6+, which is exactly what we need.
-        for(Field field : beanClass.getDeclaredFields()) {
+        for(Field field : getInheritedFields(beanClass)) {
             PropertyDescriptor propertyDescriptor = getPropertyDescriptor(propertyDescriptors, field);
             if (propertyDescriptor == null || propertyDescriptor.getWriteMethod() == null) {
                 LOG.info("Skipping "+beanClass.getName()+"."+field.getName());


### PR DESCRIPTION
Thanks a lot for the nice work. I want to contribute with this small change that makes it possible to consider also the inherited fields. In some cases it is very handy. For example, when you have a DTO POJO that has additional fields than the ones in the DAO POJO, therefore extending the DAO. The nice thing is that the annotations in the superior are automatically considered so it is possible to consider the defined fields and the inherited once while exporting or importing. For me it works great with this small change in all cases, but for other users there may be the need to enabled or disabled this behavior with an additional instruction (not considered in the commit request). 
