### PR TITLE
Bugfix/end of line multiple characters

### DIFF
--- a/src/main/java/org/csveed/row/RowInstructions.java
+++ b/src/main/java/org/csveed/row/RowInstructions.java
@@ -103,10 +103,10 @@ public interface RowInstructions {
     RowInstructions setComment(char symbol);
 
     /**
-    * Gets the character that will be used when writing End-of-line separators
-    * @return the EOL character
+    * Gets the characters that will be used when writing End-of-line separators
+    * @return the EOL characters
     */
-    char getEndOfLine();
+    char[] getEndOfLine();
 
     /**
     * Sets the characters (plural) that will be interpreted as end-of-line markers (unless within a quoted

--- a/src/main/java/org/csveed/row/RowInstructionsImpl.java
+++ b/src/main/java/org/csveed/row/RowInstructionsImpl.java
@@ -104,8 +104,8 @@ public class RowInstructionsImpl implements RowInstructions {
     }
 
     @Override
-    public char getEndOfLine() {
-        return this.symbolMapping.getFirstMappedCharacter(EncounteredSymbol.EOL_SYMBOL);
+    public char[] getEndOfLine() {
+        return this.symbolMapping.getMappedCharacters(EncounteredSymbol.EOL_SYMBOL);
     }
 
     @Override

--- a/src/main/java/org/csveed/token/SymbolMapping.java
+++ b/src/main/java/org/csveed/token/SymbolMapping.java
@@ -32,7 +32,6 @@ public class SymbolMapping {
 
     private boolean skipCommentLines = true;
 
-    //TODO: find out why this is the case
     private char acceptedEndOfLine = 0; // When multiple EOL characters have been given,
                                         // only the first one encountered will be accepted.
 

--- a/src/main/java/org/csveed/token/SymbolMapping.java
+++ b/src/main/java/org/csveed/token/SymbolMapping.java
@@ -1,14 +1,19 @@
 package org.csveed.token;
 
-import org.csveed.report.CsvException;
-import org.csveed.report.GeneralError;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.csveed.token.EncounteredSymbol.END_OF_FILE_SYMBOL;
+import static org.csveed.token.EncounteredSymbol.EOL_SYMBOL;
+import static org.csveed.token.EncounteredSymbol.EOL_SYMBOL_TRASH;
+import static org.csveed.token.EncounteredSymbol.ESCAPE_SYMBOL;
+import static org.csveed.token.EncounteredSymbol.OTHER_SYMBOL;
+import static org.csveed.token.EncounteredSymbol.QUOTE_SYMBOL;
 
 import java.util.Map;
 import java.util.TreeMap;
 
-import static org.csveed.token.EncounteredSymbol.*;
+import org.csveed.report.CsvException;
+import org.csveed.report.GeneralError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SymbolMapping {
 
@@ -27,6 +32,7 @@ public class SymbolMapping {
 
     private boolean skipCommentLines = true;
 
+    //TODO: find out why this is the case
     private char acceptedEndOfLine = 0; // When multiple EOL characters have been given,
                                         // only the first one encountered will be accepted.
 
@@ -44,8 +50,12 @@ public class SymbolMapping {
     }
 
     public char getFirstMappedCharacter(EncounteredSymbol encounteredSymbol) {
-        char[] mappedCharacters = symbolToChars.get(encounteredSymbol);
+        char[] mappedCharacters = getMappedCharacters(encounteredSymbol);
         return mappedCharacters == null ? 0 : mappedCharacters[0];
+    }
+
+    public char[] getMappedCharacters(EncounteredSymbol encounteredSymbol) {
+        return symbolToChars.get(encounteredSymbol);
     }
 
     public void addMapping(EncounteredSymbol symbol, Character character) {

--- a/src/test/java/org/csveed/api/CsvClientTest.java
+++ b/src/test/java/org/csveed/api/CsvClientTest.java
@@ -110,10 +110,20 @@ public class CsvClientTest {
     }
 
     @Test
-    public void writeRows() throws IOException {
+    public void writeRowsLF() throws IOException {
+        writeRows("\n");
+    }
+
+    @Test
+    public void writeRowsCRLF() throws IOException {
+        writeRows("\r\n");
+    }
+
+    private void writeRows(String lineTerminators) throws IOException {
         StringWriter writer = new StringWriter();
         CsvClient csvClient = new CsvClientImpl(writer)
-                .setUseHeader(false);
+                .setUseHeader(false)
+                .setEndOfLine(lineTerminators.toCharArray());
         csvClient.writeHeader(new String[] {
                 "h1", "h2", "h3"
         } );
@@ -124,10 +134,10 @@ public class CsvClientTest {
         } );
         writer.close();
         assertEquals(
-                "\"h1\";\"h2\";\"h3\"\r\n"+
-                "\"l1c1\";\"l1c2\";\"l1c3\"\r\n"+
-                "\"l2c1\";\"l2c2\";\"l2c3\"\r\n"+
-                "\"l3c1\";\"l3c2\";\"l3c3\"\r\n",
+                "\"h1\";\"h2\";\"h3\"" + lineTerminators +
+                        "\"l1c1\";\"l1c2\";\"l1c3\"" + lineTerminators +
+                        "\"l2c1\";\"l2c2\";\"l2c3\"" + lineTerminators +
+                        "\"l3c1\";\"l3c2\";\"l3c3\"" + lineTerminators,
                 writer.getBuffer().toString());
     }
 
@@ -189,36 +199,42 @@ public class CsvClientTest {
     }
 
     @Test
-    public void readLines() {
-        Reader reader = new StringReader(
-                "text,year,number,date,lines,year and month\n"+
-                "'a bit of text',1983,42.42,1972-01-13,'line 1',2013-04\n"+
-                "'more text',1984,42.42,1972-01-14,'line 1\nline 2',2014-04\n"+
-                "# please ignore me\n"+
-                "'and yet more text',1985,42.42,1972-01-15,'line 1\nline 2\nline 3',2015-04\n"
-        );
+    public void readLinesLF() {
+        readLines("\n");
+    }
+
+    @Test
+    public void readLinesCRLF() {
+        readLines("\r\n");
+    }
+
+    private void readLines(String lineTerminators) {
+        Reader reader = new StringReader("text,year,number,date,lines,year and month" + lineTerminators + "'a bit of text',1983,42.42,1972-01-13,'line 1',2013-04" + lineTerminators
+                + "'more text',1984,42.42,1972-01-14,'line 1" + lineTerminators + "line 2',2014-04" + lineTerminators + "# please ignore me"
+                + lineTerminators + "'and yet more text',1985,42.42,1972-01-15,'line 1" + lineTerminators + "line 2" + lineTerminators
+                + "line 3',2015-04" + lineTerminators);
 
         CsvClient<BeanVariousNotAnnotated> csvClient =
                 new CsvClientImpl<BeanVariousNotAnnotated>(reader, BeanVariousNotAnnotated.class)
-                .setEscape('\\')
-                .setQuote('\'')
-                .setComment('#')
-                .setEndOfLine(new char[]{'\n'})
-                .setSeparator(',')
-                .setStartRow(1)
-                .setUseHeader(true)
-                .setMapper(ColumnNameMapper.class)
-                .ignoreProperty("ignoreMe")
-                .mapColumnNameToProperty("text", "txt")
-                .setRequired("txt", true)
-                .mapColumnNameToProperty("year", "year")
-                .mapColumnNameToProperty("number", "number")
-                .mapColumnNameToProperty("date", "date")
-                .setDate("date", "yyyy-MM-dd")
-                .mapColumnNameToProperty("year and month", "yearMonth")
-                .setDate("yearMonth", "yyyy-MM")
-                .mapColumnNameToProperty("lines", "simple")
-                .setConverter("simple", new BeanSimpleConverter())
+                        .setEscape('\\')
+                        .setQuote('\'')
+                        .setComment('#')
+                        .setEndOfLine(new char[]{'\n'})
+                        .setSeparator(',')
+                        .setStartRow(1)
+                        .setUseHeader(true)
+                        .setMapper(ColumnNameMapper.class)
+                        .ignoreProperty("ignoreMe")
+                        .mapColumnNameToProperty("text", "txt")
+                        .setRequired("txt", true)
+                        .mapColumnNameToProperty("year", "year")
+                        .mapColumnNameToProperty("number", "number")
+                        .mapColumnNameToProperty("date", "date")
+                        .setDate("date", "yyyy-MM-dd")
+                        .mapColumnNameToProperty("year and month", "yearMonth")
+                        .setDate("yearMonth", "yyyy-MM")
+                        .mapColumnNameToProperty("lines", "simple")
+                        .setConverter("simple", new BeanSimpleConverter())
                 ;
 
         List<BeanVariousNotAnnotated> beans = csvClient.readBeans();

--- a/src/test/java/org/csveed/api/CsvClientTest.java
+++ b/src/test/java/org/csveed/api/CsvClientTest.java
@@ -38,10 +38,10 @@ public class CsvClientTest {
         client.writeBeans(beans);
         writer.close();
         assertEquals(
-                "\"gamma\";\"beta\";\"alpha\"\r"+
-                "\"row 1, cell 1\";\"row 1, cell 2\";\"row 1, cell 3\"\r"+
-                "\"row 2, cell 1\";\"row 2, cell 2\";\"row 2, cell 3\"\r"+
-                "\"row 3, cell 1\";\"row 3, cell 2\";\"row 3, cell 3\"\r",
+                "\"gamma\";\"beta\";\"alpha\"\r\n"+
+                "\"row 1, cell 1\";\"row 1, cell 2\";\"row 1, cell 3\"\r\n"+
+                "\"row 2, cell 1\";\"row 2, cell 2\";\"row 2, cell 3\"\r\n"+
+                "\"row 3, cell 1\";\"row 3, cell 2\";\"row 3, cell 3\"\r\n",
                 writer.getBuffer().toString());
     }
 
@@ -61,10 +61,10 @@ public class CsvClientTest {
         client.writeBeans(beans);
         writer.close();
         assertEquals(
-                "\"beta\";\"alpha\"\r"+
-                "\"row 1, cell 2\";\"row 1, cell 3\"\r"+
-                "\"row 2, cell 2\";\"row 2, cell 3\"\r"+
-                "\"row 3, cell 2\";\"row 3, cell 3\"\r",
+                "\"beta\";\"alpha\"\r\n"+
+                "\"row 1, cell 2\";\"row 1, cell 3\"\r\n"+
+                "\"row 2, cell 2\";\"row 2, cell 3\"\r\n"+
+                "\"row 3, cell 2\";\"row 3, cell 3\"\r\n",
                 writer.getBuffer().toString());
     }
 
@@ -93,9 +93,9 @@ public class CsvClientTest {
         writer.close();
 
         assertEquals(
-                "\"alpha\";\"beta\";\"gamma\"\r"+
-                "\"row 1, cell 1\";\"row 1, cell 2\";\"row 1, cell 3\"\r"+
-                "\"row 2, cell 1\";\"row 2, cell 2\";\"row 2, cell 3\"\r",
+                "\"alpha\";\"beta\";\"gamma\"\r\n"+
+                "\"row 1, cell 1\";\"row 1, cell 2\";\"row 1, cell 3\"\r\n"+
+                "\"row 2, cell 1\";\"row 2, cell 2\";\"row 2, cell 3\"\r\n",
                 writer.getBuffer().toString());
     }
 
@@ -106,7 +106,7 @@ public class CsvClientTest {
                 .setUseHeader(false);
         csvClient.writeRow(new String[] { "alpha", "beta", "gamma" } );
         writer.close();
-        assertEquals("\"alpha\";\"beta\";\"gamma\"\r", writer.getBuffer().toString());
+        assertEquals("\"alpha\";\"beta\";\"gamma\"\r\n", writer.getBuffer().toString());
     }
 
     @Test
@@ -124,10 +124,10 @@ public class CsvClientTest {
         } );
         writer.close();
         assertEquals(
-                "\"h1\";\"h2\";\"h3\"\r"+
-                "\"l1c1\";\"l1c2\";\"l1c3\"\r"+
-                "\"l2c1\";\"l2c2\";\"l2c3\"\r"+
-                "\"l3c1\";\"l3c2\";\"l3c3\"\r",
+                "\"h1\";\"h2\";\"h3\"\r\n"+
+                "\"l1c1\";\"l1c2\";\"l1c3\"\r\n"+
+                "\"l2c1\";\"l2c2\";\"l2c3\"\r\n"+
+                "\"l3c1\";\"l3c2\";\"l3c3\"\r\n",
                 writer.getBuffer().toString());
     }
 
@@ -309,6 +309,6 @@ public class CsvClientTest {
         );
         client.writeHeader();
         writer.close();
-        assertEquals("\"gamma\";\"beta\";\"alpha\"\r", writer.getBuffer().toString());
+        assertEquals("\"gamma\";\"beta\";\"alpha\"\r\n", writer.getBuffer().toString());
     }
 }

--- a/src/test/java/org/csveed/bean/BeanWriterTest.java
+++ b/src/test/java/org/csveed/bean/BeanWriterTest.java
@@ -1,16 +1,14 @@
 package org.csveed.bean;
 
-import org.csveed.bean.conversion.Bean;
-import org.csveed.report.CsvException;
-import org.csveed.test.model.BeanWithMultipleStrings;
-import org.junit.Test;
+import static junit.framework.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
+import org.csveed.test.model.BeanWithMultipleStrings;
+import org.junit.Test;
 
 public class BeanWriterTest {
     
@@ -26,10 +24,10 @@ public class BeanWriterTest {
         beanWriter.writeBeans(beans);
         writer.close();
         assertEquals(
-                "\"gamma\";\"beta\";\"alpha\"\r"+
-                "\"row 1, cell 1\";\"row 1, cell 2\";\"row 1, cell 3\"\r"+
-                "\"row 2, cell 1\";\"row 2, cell 2\";\"row 2, cell 3\"\r"+
-                "\"row 3, cell 1\";\"row 3, cell 2\";\"row 3, cell 3\"\r",
+                "\"gamma\";\"beta\";\"alpha\"\r\n"+
+                "\"row 1, cell 1\";\"row 1, cell 2\";\"row 1, cell 3\"\r\n"+
+                "\"row 2, cell 1\";\"row 2, cell 2\";\"row 2, cell 3\"\r\n"+
+                "\"row 3, cell 1\";\"row 3, cell 2\";\"row 3, cell 3\"\r\n",
                 writer.getBuffer().toString());
     }
 
@@ -52,10 +50,10 @@ public class BeanWriterTest {
         beanWriter.writeBeans(beans);
         writer.close();
         assertEquals(
-                "\"Aap\";\"Noot\";\"Mies\"\r"+
-                "\"row 1, cell 1\";\"row 1, cell 2\";\"row 1, cell 3\"\r"+
-                "\"row 2, cell 1\";\"row 2, cell 2\";\"row 2, cell 3\"\r"+
-                "\"row 3, cell 1\";\"row 3, cell 2\";\"row 3, cell 3\"\r",
+                "\"Aap\";\"Noot\";\"Mies\"\r\n"+
+                "\"row 1, cell 1\";\"row 1, cell 2\";\"row 1, cell 3\"\r\n"+
+                "\"row 2, cell 1\";\"row 2, cell 2\";\"row 2, cell 3\"\r\n"+
+                "\"row 3, cell 1\";\"row 3, cell 2\";\"row 3, cell 3\"\r\n",
                 writer.getBuffer().toString());
     }
 

--- a/src/test/java/org/csveed/row/RowWriterTest.java
+++ b/src/test/java/org/csveed/row/RowWriterTest.java
@@ -33,9 +33,9 @@ public class RowWriterTest {
 
         writer.close();
         assertEquals(
-                "\"alpha\";\"beta\";\"gamma\"\r"+
-                "\"row 1, cell 1\";\"row 1, cell 2\";\"row 1, cell 3\"\r"+
-                "\"row 2, cell 1\";\"row 2, cell 2\";\"row 2, cell 3\"\r",
+                "\"alpha\";\"beta\";\"gamma\"\r\n"+
+                "\"row 1, cell 1\";\"row 1, cell 2\";\"row 1, cell 3\"\r\n"+
+                "\"row 2, cell 1\";\"row 2, cell 2\";\"row 2, cell 3\"\r\n",
                 writer.getBuffer().toString());
     }
 
@@ -52,10 +52,10 @@ public class RowWriterTest {
         });
         writer.close();
         assertEquals(
-                "\"desc1\";\"desc2\";\"desc3\"\r"+
-                "\"alpha\";\"beta\";\"gamma\"\r"+
-                "\"delta\";\"epsilon\";\"phi\"\r"+
-                "\"b1\";\"b2\";\"b3\"\r",
+                "\"desc1\";\"desc2\";\"desc3\"\r\n"+
+                "\"alpha\";\"beta\";\"gamma\"\r\n"+
+                "\"delta\";\"epsilon\";\"phi\"\r\n"+
+                "\"b1\";\"b2\";\"b3\"\r\n",
                 writer.getBuffer().toString());
     }
 
@@ -68,7 +68,7 @@ public class RowWriterTest {
         RowWriter rowWriter = new RowWriterImpl(writer, instructions);
         rowWriter.writeRow(new String[] { "\"tekst met \"quotes\"\"" } );
         writer.close();
-        assertEquals("\"\\\"tekst met \\\"quotes\\\"\\\"\"\r", writer.getBuffer().toString());
+        assertEquals("\"\\\"tekst met \\\"quotes\\\"\\\"\"\r\n", writer.getBuffer().toString());
     }
 
     @Test
@@ -79,7 +79,7 @@ public class RowWriterTest {
         RowWriter rowWriter = new RowWriterImpl(writer, instructions);
         rowWriter.writeRow(new String[] { "alpha", "beta", "gamma" } );
         writer.close();
-        assertEquals("\"alpha\";\"beta\";\"gamma\"\r", writer.getBuffer().toString());
+        assertEquals("\"alpha\";\"beta\";\"gamma\"\r\n", writer.getBuffer().toString());
     }
 
     @Test
@@ -91,7 +91,7 @@ public class RowWriterTest {
         RowWriter rowWriter = new RowWriterImpl(writer, instructions);
         rowWriter.writeRow(new String[] { "alpha", "beta", "gamma" } );
         writer.close();
-        assertEquals("alpha;beta;gamma\r", writer.getBuffer().toString());
+        assertEquals("alpha;beta;gamma\r\n", writer.getBuffer().toString());
     }
 
     @Test
@@ -103,7 +103,7 @@ public class RowWriterTest {
         RowWriter rowWriter = new RowWriterImpl(writer, instructions);
         rowWriter.writeRow(new String[] { "\"tekst met \"quotes\"\"" } );
         writer.close();
-        assertEquals("\"tekst met \"quotes\"\"\r", writer.getBuffer().toString());
+        assertEquals("\"tekst met \"quotes\"\"\r\n", writer.getBuffer().toString());
     }
 
 
@@ -115,7 +115,7 @@ public class RowWriterTest {
         RowWriter rowWriter = new RowWriterImpl(writer, instructions);
         rowWriter.writeRow(new String[] { "alpha", null, "gamma" } );
         writer.close();
-        assertEquals("\"alpha\";\"\";\"gamma\"\r", writer.getBuffer().toString());
+        assertEquals("\"alpha\";\"\";\"gamma\"\r\n", writer.getBuffer().toString());
     }
 
     @Test
@@ -126,8 +126,8 @@ public class RowWriterTest {
         rowWriter.writeRow(new String[] { "alpha", "beta", "gamma" } );
         writer.close();
         assertEquals(
-                "\"desc1\";\"desc2\";\"desc3\"\r"+
-                "\"alpha\";\"beta\";\"gamma\"\r",
+                "\"desc1\";\"desc2\";\"desc3\"\r\n"+
+                "\"alpha\";\"beta\";\"gamma\"\r\n",
                 writer.getBuffer().toString());
     }
 


### PR DESCRIPTION
Now supporting multiple character line termination symbols when writing CSV files. Previously setting the endOfLine symbol to \r\n resulted in only \r termination symbols.